### PR TITLE
Feat/comments likes

### DIFF
--- a/backend/src/routes/likes.ts
+++ b/backend/src/routes/likes.ts
@@ -21,58 +21,14 @@ router.post("/", async (req, res) => {
 router.delete("/", async (req, res) => {
   const { user_id, post_id } = req.body;
   try {
-    await pool.query(
-      `DELETE FROM likes WHERE user_id = $1 AND post_id = $2`,
-      [user_id, post_id]
-    );
+    await pool.query(`DELETE FROM likes WHERE user_id = $1 AND post_id = $2`, [
+      user_id,
+      post_id,
+    ]);
     res.json({ message: "Unliked successfully" });
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
   }
 });
-
-// ✅ Get like count & check if user liked
-router.get("/nailed/:userId", async (req, res) => {
-    const profileUserId = req.params.userId;
-    const viewerUserId = req.query.viewerId;
-  
-    try {
-      const result = await pool.query(`
-        SELECT 
-          posts.id AS post_id,
-          posts.goal_id AS goal_id,
-          posts.title,
-          posts.description,
-          posts.duration,
-          posts.image_url,
-          COUNT(likes.id) AS like_count,
-          EXISTS (
-            SELECT 1 FROM likes WHERE post_id = posts.id AND user_id = $2
-          ) AS liked_by_me,
-          (
-            SELECT json_agg(json_build_object(
-              'id', comments.id,
-              'user_id', comments.user_id,
-              'username', users.username,
-              'content', comments.content,
-              'created_at', comments.created_at
-            ))
-            FROM comments
-            JOIN users ON users.id = comments.user_id
-            WHERE comments.post_id = posts.id
-          ) AS comments
-        FROM posts
-        LEFT JOIN likes ON posts.id = likes.post_id
-        WHERE posts.user_id = $1
-        GROUP BY posts.id
-      `, [profileUserId, viewerUserId]);
-  
-      console.log("Server response:", result.rows); // 서버 로그 추가
-      res.json(result.rows);
-    } catch (err) {
-      res.status(500).json({ error: (err as Error).message });
-    }
-  });
-  
 
 export default router;

--- a/backend/src/routes/posts.ts
+++ b/backend/src/routes/posts.ts
@@ -88,7 +88,6 @@ router.get("/nailed/:userId", async (req: Request, res: Response) => {
       [profileUserId, viewerUserId]
     );
 
-    console.log("Server response:", result.rows);
     res.json(result.rows);
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });

--- a/backend/src/routes/posts.ts
+++ b/backend/src/routes/posts.ts
@@ -60,7 +60,7 @@ router.get("/nailed/:userId", async (req: Request, res: Response) => {
         goals.duration,
         posts.image_url,
         posts.description,
-        COUNT(likes.id) AS like_count,
+        CAST(COUNT(likes.id) AS INTEGER) AS like_count,
         EXISTS (
           SELECT 1 FROM likes WHERE post_id = posts.id AND user_id = $2
         ) AS liked_by_me,

--- a/backend/src/routes/posts.ts
+++ b/backend/src/routes/posts.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response,RequestHandler } from "express";
+import express, { Request, Response, RequestHandler } from "express";
 import pool from "../db";
 import multer from "multer";
 import cloudinary from "../utils/cloudinary";
@@ -23,47 +23,76 @@ router.post("/", async (req: Request, res: Response) => {
 });
 
 // ✅ Upload post image to Cloudinary
-router.post("/upload-image", upload.single("image"), (async (req: Request, res: Response) => {
-    try {
-      const file = req.file;
-      if (!file) return res.status(400).json({ error: "No file uploaded" });
-  
-      const base64 = `data:${file.mimetype};base64,${file.buffer.toString("base64")}`;
-  
-      const uploadRes = await cloudinary.uploader.upload(base64, {
-        folder: "post_images",
-      });
-  
-      res.json({ imageUrl: uploadRes.secure_url });
-    } catch (err) {
-      console.error("Cloudinary upload failed:", err);
-      res.status(500).json({ error: "Image upload failed" });
-    }
-  }) as RequestHandler);
-  
+router.post("/upload-image", upload.single("image"), (async (
+  req: Request,
+  res: Response
+) => {
+  try {
+    const file = req.file;
+    if (!file) return res.status(400).json({ error: "No file uploaded" });
+
+    const base64 = `data:${file.mimetype};base64,${file.buffer.toString(
+      "base64"
+    )}`;
+
+    const uploadRes = await cloudinary.uploader.upload(base64, {
+      folder: "post_images",
+    });
+
+    res.json({ imageUrl: uploadRes.secure_url });
+  } catch (err) {
+    console.error("Cloudinary upload failed:", err);
+    res.status(500).json({ error: "Image upload failed" });
+  }
+}) as RequestHandler);
 
 // ✅ Get "nailed it" goals + post data for a user
 router.get("/nailed/:userId", async (req: Request, res: Response) => {
-    const { userId } = req.params;
-    try {
-      const result = await pool.query(`
-        SELECT 
-          g.id AS goal_id,
-          g.title,
-          g.duration,
-          p.image_url,
-          p.description
-        FROM goals g
-        JOIN posts p ON g.id = p.goal_id
-        WHERE g.user_id = $1 AND g.status = 'nailed it'
-        ORDER BY g.created_at DESC
-      `, [userId]);
-  
-      res.json(result.rows);
-    } catch (err) {
-      res.status(500).json({ error: (err as Error).message });
-    }
-  });
-  
+  const profileUserId = req.params.userId;
+  const viewerUserId = req.query.viewerId as string;
+  try {
+    const result = await pool.query(
+      `
+      SELECT 
+        posts.id AS post_id,
+        posts.goal_id AS goal_id,
+        goals.title,
+        goals.duration,
+        posts.image_url,
+        posts.description,
+        COUNT(likes.id) AS like_count,
+        EXISTS (
+          SELECT 1 FROM likes WHERE post_id = posts.id AND user_id = $2
+        ) AS liked_by_me,
+        COALESCE(
+          (
+            SELECT json_agg(json_build_object(
+              'id', comments.id,
+              'user_id', comments.user_id,
+              'username', users.username,
+              'content', comments.content,
+              'created_at', comments.created_at
+            ))
+            FROM comments
+            JOIN users ON users.id = comments.user_id
+            WHERE comments.post_id = posts.id
+          ),
+          '[]'::json
+        ) AS comments
+      FROM posts
+      JOIN goals ON posts.goal_id = goals.id
+      LEFT JOIN likes ON posts.id = likes.post_id
+      WHERE posts.user_id = $1 AND goals.status = 'nailed it'
+      GROUP BY posts.id, posts.goal_id, goals.title, goals.duration, posts.image_url, posts.description, goals.created_at
+      ORDER BY goals.created_at DESC`,
+      [profileUserId, viewerUserId]
+    );
+
+    console.log("Server response:", result.rows);
+    res.json(result.rows);
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
 
 export default router;

--- a/frontend/src/app/dashboard/[userId]/components/NailedPostsTab.tsx
+++ b/frontend/src/app/dashboard/[userId]/components/NailedPostsTab.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { likePost, unlikePost, addComment } from "@/utils/api";
+import { likePost, unlikePost, addComment, Post } from "@/utils/api";
 import {
   Select,
   SelectContent,
@@ -7,20 +7,8 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 
-interface NailedPost {
-  post_id: number;
-  goal_id: number;
-  title: string;
-  duration: number;
-  image_url: string;
-  description: string;
-  like_count: number;
-  liked_by_me: boolean;
-  comments: { id: number; user_id: number; username: string; content: string; created_at: string }[];
-}
-
 interface NailedPostsTabProps {
-  posts: NailedPost[];
+  posts: Post[];
   userId: number | null;
 }
 
@@ -33,7 +21,7 @@ const NailedPostsTab = ({ posts, userId }: NailedPostsTabProps) => {
     posts.reduce((acc, post) => ({ ...acc, [post.post_id]: post.like_count }), {})
   );
   const [newComments, setNewComments] = useState<{ [key: number]: string }>({});
-  const [updatedPosts, setUpdatedPosts] = useState<NailedPost[]>(posts);
+  const [updatedPosts, setUpdatedPosts] = useState<Post[]>(posts);
 
   const sortedPosts = [...updatedPosts].sort((a, b) => {
     if (sortBy === "latest") return b.goal_id - a.goal_id;


### PR DESCRIPTION
## Description
This PR refactors and modifies the Likes and Posts logic to address multiple bugs, improve code stability, and enhance readability. The key changes include:

- Likes Logic Fixes:
  - Fixed an issue where like_count was being treated as a string, causing incorrect concatenation (e.g., 01, 11, 10) instead of proper numeric increments/decrements. Server-side COUNT(likes.id) is now explicitly cast to an integer using CAST(COUNT(likes.id) AS INTEGER), and client-side likeCounts state ensures numeric operations with Number() conversion.
  - Improved handleLike function in NailedPostsTab.tsx to prevent negative counts and ensure consistent state updates.

- Posts Logic Refactoring:
  - Corrected a SQL syntax error in posts.ts where duplicate ORDER BY goals.created_at DESC clauses caused a 500 Internal Server Error. Removed the redundant clause.
  - Fixed a GROUP BY error by adding goals.created_at to the GROUP BY clause in the /nailed/:userId endpoint, ensuring compatibility with PostgreSQL’s strict grouping rules.
  - Enhanced the /nailed/:userId endpoint to include post_id, like_count, liked_by_me, and comments in the response, ensuring all required fields are available for the frontend.

- Code Cleanup:
  - Simplified client-side NailedPostsTab.tsx by ensuring numeric handling of like_count and improving state initialization with proper type safety.
  - Standardized error handling and logging across server and client for better debugging (e.g., added console.log for server responses and client actions).

## Why
These changes were necessary to resolve several critical issues:

- Incorrect Like Counts: The frontend displayed like_count incorrectly (e.g., 01 instead of 1, 11 instead of 2) due to string concatenation instead of numeric operations, degrading user experience.
- Server Errors: Duplicate ORDER BY and missing GROUP BY fields in the SQL query caused 500 errors, breaking the /posts/nailed/:userId endpoint and preventing data retrieval.
- Feature Completeness: The original Posts response lacked essential fields like post_id, breaking downstream functionality such as liking posts.
- Maintainability: The previous code mixed string and numeric types inconsistently and had redundant logic, making it harder to maintain and debug.

This refactoring improves reliability, ensures correct behavior of the likes system, and aligns the server response with frontend expectations.

## Testing
- Server: Tested the /api/posts/nailed/4?viewerId=4 endpoint using Postman to verify a 200 OK response with correct fields (post_id, like_count as a number, etc.).
- Likes: Clicked the "Like" button in NailedPostsTab to confirm like_count increments from 0 to 1, then 2, and decrements back to 1 and 0 without string artifacts (e.g., no 01 or 11).
- Posts: Loaded the dashboard to ensure nailed posts render correctly with all expected data (title, duration, image, etc.).
- Database: Queried likes table (SELECT * FROM likes WHERE user_id = 4) after liking/unliking to verify post_id is correctly stored.

## Linked Issues
Fixes #28 
