### PR TITLE
Feat/nickname duplication

### DIFF
--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -38,6 +38,14 @@ router.patch("/:userId", (async (req: Request, res: Response) => {
   const { username } = req.body;
 
   try {
+    const usernameCheck = await pool.query(
+      "SELECT id FROM users WHERE username = $1 AND id != $2",
+      [username, userId]
+    );
+    if (usernameCheck.rows.length > 0) {
+      return res.status(409).json({ error: "Username already exists" });
+    }
+    
     const result = await pool.query(
       "UPDATE users SET username = $1 WHERE id = $2 RETURNING id, username, email",
       [username, userId]

--- a/frontend/src/app/contexts/AuthContext.tsx
+++ b/frontend/src/app/contexts/AuthContext.tsx
@@ -158,16 +158,23 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     if (!username || username.trim() === "") {
       throw new Error("Username cannot be empty");
     }
-    const updatedUser = await fetchApi<User>(`/profile/${userId}`, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ username }),
-    });
-    setUser(updatedUser);
-    localStorage.setItem(USER_KEY, JSON.stringify(updatedUser));
+    try {
+      const updatedUser = await fetchApi<User>(`/profile/${userId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ username }),
+      });
+      setUser(updatedUser);
+      localStorage.setItem(USER_KEY, JSON.stringify(updatedUser));
+    } catch (err: any) {
+      if (err.message === "Username already exists") {
+        throw new Error("Username is already taken");
+      }
+      throw new Error("Failed to update profile");
+    }
   };
 
   const updateProfileImage = async (userId: number, file: File) => {

--- a/frontend/src/app/profile/ProfileForm.tsx
+++ b/frontend/src/app/profile/ProfileForm.tsx
@@ -18,10 +18,15 @@ const ProfileForm = ({ username, onUpdate, onCancel }: ProfileFormProps) => {
       setError("Username cannot be empty!");
       return;
     }
+    if (nickname === username) {
+      onCancel(); // No change, just close the form
+      return;
+    }
+    
     setError(null);
 
     try {
-      await onUpdate(nickname);
+      onUpdate(nickname);
       setError(null);
     } catch (err: any) {
       if (err.message === "Username is already taken") {

--- a/frontend/src/app/profile/ProfileForm.tsx
+++ b/frontend/src/app/profile/ProfileForm.tsx
@@ -8,30 +8,56 @@ interface ProfileFormProps {
   onCancel: () => void;
 }
 
-const ProfileForm = ({ username, onUpdate,onCancel }: ProfileFormProps) => {
+const ProfileForm = ({ username, onUpdate, onCancel }: ProfileFormProps) => {
   const [nickname, setNickname] = useState(username);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (nickname.trim() === "") return;
-    onUpdate(nickname);
-  };
+    if (nickname.trim() === "") {
+      setError("Username cannot be empty!");
+      return;
+    }
+    setError(null);
 
+    try {
+      await onUpdate(nickname);
+      setError(null);
+    } catch (err: any) {
+      if (err.message === "Username is already taken") {
+        setError("Username is already taken!");
+      } else {
+        setError("Failed to update profile!");
+      }
+    }
+  };
   return (
     <div className="p-4 bg-white rounded-lg shadow-md">
-      <h1 className="text-lg font-semibold text-center">{username}'s Profile</h1>
+      <h1 className="text-lg font-semibold text-center">
+        {username}'s Profile
+      </h1>
       <form onSubmit={handleSubmit} className="mt-2">
-        <label htmlFor="name" className="block text-sm font-medium">Name</label>
+        <label htmlFor="name" className="block text-sm font-medium">
+          Name
+        </label>
         <input
           type="text"
           id="name"
-          className="w-full p-2 border border-gray-300 rounded-md"
+          className={`w-full p-2 border rounded-md ${
+            error?.includes("Username") ? "border-red-500" : "border-gray-300"
+          }`}
           value={nickname}
           onChange={(e) => setNickname(e.target.value)}
           required
         />
+        {error && <p className="text-red-500 text-xs mt-1">{error}</p>}
         <div className="mt-3 flex justify-between">
-          <button type="submit" className="bg-emerald-500 text-white px-4 py-2 rounded-md">Save</button>
+          <button
+            type="submit"
+            className="bg-emerald-500 text-white px-4 py-2 rounded-md"
+          >
+            Save
+          </button>
           <button
             type="button"
             className="bg-gray-200 text-black px-4 py-2 rounded-md"

--- a/frontend/src/app/profile/ProfileForm.tsx
+++ b/frontend/src/app/profile/ProfileForm.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 
 interface ProfileFormProps {
   username: string;
-  onUpdate: (nickname: string) => void;
+  onUpdate: (nickname: string) => Promise<void>;
   onCancel: () => void;
 }
 
@@ -22,11 +22,11 @@ const ProfileForm = ({ username, onUpdate, onCancel }: ProfileFormProps) => {
       onCancel(); // No change, just close the form
       return;
     }
-    
+
     setError(null);
 
     try {
-      onUpdate(nickname);
+      await onUpdate(nickname);
       setError(null);
     } catch (err: any) {
       if (err.message === "Username is already taken") {

--- a/frontend/src/app/profile/[userId]/page.tsx
+++ b/frontend/src/app/profile/[userId]/page.tsx
@@ -62,6 +62,7 @@ const ProfilePage = () => {
       } else {
         setErrorMessage("Failed to update profile!");
       }
+      throw err;
     }
   };
 

--- a/frontend/src/app/profile/[userId]/page.tsx
+++ b/frontend/src/app/profile/[userId]/page.tsx
@@ -52,8 +52,17 @@ const ProfilePage = () => {
   }, [imagePreview]);
 
   const handleUpdateUsername = async (newUsername: string) => {
-    await updateProfile(Number(userId), newUsername);
-    setIsEditing(false);
+    try {
+      await updateProfile(Number(userId), newUsername);
+      setIsEditing(false);
+      setErrorMessage(null);
+    } catch (err: any) {
+      if (err.message === "Username is already taken") {
+        setErrorMessage("Username is already taken!");
+      } else {
+        setErrorMessage("Failed to update profile!");
+      }
+    }
   };
 
   const handleImageUpload = async () => {
@@ -212,7 +221,10 @@ const ProfilePage = () => {
           <ProfileForm
             username={user.username}
             onUpdate={handleUpdateUsername}
-            onCancel={() => setIsEditing(false)}
+            onCancel={() => {
+              setIsEditing(false);
+              setErrorMessage(null);
+            }}
           />
         </div>
       )}

--- a/frontend/src/app/signup/SignupForm.tsx
+++ b/frontend/src/app/signup/SignupForm.tsx
@@ -7,15 +7,18 @@ import ErrorIcon from "../../../public/icons/ErrorIcon";
 import { useAuth } from "../contexts/AuthContext";
 
 const SignupForm = () => {
+  const { signup } = useAuth();
   const router = useRouter();
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [username, setUsername] = useState("");
-  const { signup } = useAuth();
-  
+  const [error, setError] = useState<string | null>(null);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError(null);
 
     if (password !== confirmPassword) {
       alert("Passwords do not match!");
@@ -26,8 +29,12 @@ const SignupForm = () => {
       await signup(username, email, password);
       alert("Signup successful! Please log in.");
       router.push("/login");
-    } catch (error) {
-      alert("Signup failed!");
+    } catch (error: any) {
+      if (error.message === "Username is already taken") {
+        setError("Username is already taken!");
+      } else {
+        setError("Signup failed!");
+      }
     }
   };
 
@@ -87,11 +94,21 @@ const SignupForm = () => {
           <input
             type="text"
             placeholder="Username"
-            className="border text-gray-900 border-primary-400 px-2 py-1 rounded text-sm focus:outline-none focus:border-primary-600"
+            className={`border text-gray-900 px-2 py-1 rounded text-sm focus:outline-none ${
+              error?.includes("Username")
+                ? "border-red-500"
+                : "border-primary-400 focus:border-primary-600"
+            }`}
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             required
           />
+
+          {error && (
+            <div className="text-red-500 text-xs flex flex-row">
+              <ErrorIcon /> {error}
+            </div>
+          )}
 
           <button
             type="submit"


### PR DESCRIPTION
## Description
This pull request addresses an issue where the application crashed with an "Unhandled Runtime Error: Username already exists" when attempting to update a user profile with a duplicate nickname. The changes ensure that:

- The backend (profile.ts) correctly returns a 409 Conflict status when a duplicate username is detected, preventing it from being saved to the database.
- The AuthContext.tsx now properly catches and rethrows the duplication error as "Username is already taken" for consistent error handling.
- The ProfileForm.tsx component awaits the asynchronous onUpdate call and displays the error message in the UI (e.g., "Username is already taken!") without crashing.
- The page.tsx (/profile/[userId]) component propagates errors to ProfileForm and clears them appropriately when the form is canceled or succeeds.

Key fixes include:
- Added try/catch in AuthContext.tsx’s updateProfile to handle 409 errors.
- Updated ProfileForm.tsx to use await on onUpdate and reflect errors in the UI with a red border and message.
- Ensured page.tsx maintains a consistent error state and avoids unhandled promise rejections.

## Why
The previous implementation had several issues:
- The fetchApi function threw an error on 409 Conflict responses, but updateProfile in AuthContext.tsx didn’t catch it, leading to unhandled promise rejections and app crashes.
- Users weren’t informed of nickname duplication in the UI; instead, the app broke silently.
- The database allowed duplicate usernames to be saved due to insufficient error handling in the frontend chain.

These changes solve:
-User Experience: Users now see a clear "Username is already taken!" message in the form when they try to use an existing nickname.
- Stability: The app no longer crashes due to unhandled errors.
- Data Integrity: Duplicate nicknames are prevented from being saved by proper backend validation and frontend feedback.

This improves the reliability of the profile update feature and ensures a smoother user experience.

## Testing
- Duplicate Nickname: Edited a profile with an existing username (e.g., tried changing user ID 4’s username to one used by user ID 1). Verified that:
  - The backend returns 409 Conflict with "Username already exists".
  - The ProfileForm displays "Username is already taken!" with a red input border.
  - The app doesn’t crash, and no "Unhandled Runtime Error" appears in the console.
- Unique Nickname: Updated the username to a unique value. Confirmed that:
  - The profile updates successfully, the modal closes, and the UI reflects the new username.
- Empty Input: Submitted an empty username. Ensured "Username cannot be empty!" appears in the form.
- No Change: Submitted the current username. Verified the form closes without errors.
- Cancel: Clicked "Cancel" during editing. Checked that the modal closes and any error messages are cleared.

## Linked Issues
Fixes #45 
