### PR TITLE
🐛  fix: Simplify ForgotPasswordForm submit button by removing unneces…

### DIFF
--- a/frontend/src/app/forgot-password/ForgotPasswordForm.tsx
+++ b/frontend/src/app/forgot-password/ForgotPasswordForm.tsx
@@ -46,7 +46,7 @@ const ForgotPasswordForm = () => {
             onChange={(e) => setEmail(e.target.value)}
           />
 
-          <GlobalButton type="submit" onClick={() => router.back()}>send</GlobalButton>
+          <GlobalButton type="submit">send</GlobalButton>
         </form>
       </div>
 


### PR DESCRIPTION
## Description
This change fixes a routing issue on the "Forgot Password" page where submitting the form incorrectly redirected to the /login page before showing an alert and then moving to /reset-password. The fix removes an unnecessary onClick={() => router.back()} from the GlobalButton, ensuring the form submission directly navigates to /reset-password?email=... after the email reset request.

## Why
The original code had a conflicting onClick event on the submit button that triggered router.back(), causing an unwanted redirect to /login before the intended /reset-password navigation. This disrupted the user flow and created confusion. Removing the onClick resolves this, ensuring a smooth transition to the reset password page as expected.

## Testing
- Entered an email and clicked "send".
- Verified the alert ("Check your email for the reset code!") appears, followed by an immediate redirect to /reset-password?email=... without going to /login.

## Linked Issues
Fixes #<!-- Link to the issue this PR resolves -->
