### PR TITLE
🐛 fix: Simplify GoalForm by removing onGoalCreated prop and handle na…

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import GoalForm from "../components/GoalForm";
+import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "./contexts/AuthContext";
 import { usePosts } from "./contexts/PostContext";
-import { useCallback, useEffect, useState } from "react";
 import { Post } from "@/utils/api";
+import GoalForm from "../components/GoalForm";
 import PostsList from "@/components/PostsList";
 
 const Page = () => {
@@ -28,16 +27,9 @@ const Page = () => {
     fetchAndShufflePosts();
   }, [fetchAndShufflePosts, user]);
 
-  const router = useRouter();
-  const handleGoalCreated = () => {
-    if (user) {
-      router.push(`/dashboard/${user.id}`);
-    }
-  };
-
   return (
     <>
-      <GoalForm onGoalCreated={handleGoalCreated} />
+      <GoalForm />
       <PostsList posts={posts} userId={user ? Number(user.id) : null} />
     </>
   );

--- a/frontend/src/components/GoalForm.tsx
+++ b/frontend/src/components/GoalForm.tsx
@@ -11,7 +11,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { toast } from "sonner";
 
-const GoalForm = ({ onGoalCreated }: { onGoalCreated: () => void }) => {
+const GoalForm = () => {
   const { createGoal, updateGoal } = useGoals();
   const { createPost } = usePosts();
   const { user } = useAuth();
@@ -56,7 +56,6 @@ const GoalForm = ({ onGoalCreated }: { onGoalCreated: () => void }) => {
     try {
       const newGoal = await createGoal(user.id, title, duration);
       startTimer(newGoal.id, duration);
-      onGoalCreated();
     } catch (err) {
       toast.error("error creating goal");
     }
@@ -73,6 +72,7 @@ const GoalForm = ({ onGoalCreated }: { onGoalCreated: () => void }) => {
 
     await createPost(user.id, goalId, imageUrl, description);
     setShowPostModal(false);
+    router.push(`/dashboard/${user.id}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description
This change fixes a routing bug in GoalForm.tsx where users were redirected to the dashboard before the timer completed. The issue stemmed from the onGoalCreated callback in the parent page.tsx, which triggered an immediate redirect to /dashboard/${user.id} after goal creation. The fix removes the onGoalCreated prop, ensuring the timer runs its full course, and adds explicit redirects to /dashboard only after timer completion (via PostModal submission) or failure (via handleFailOut, tab switch, or refresh).

## Why
The premature redirect disrupted the intended flow of the GoalForm, where users should stay on the page until the timer finishes or fails. This was caused by the parent component’s handleGoalCreated function, which didn’t account for the timer’s lifecycle. By removing the callback and managing routing within GoalForm, the change ensures users complete or fail the goal before navigating away, aligning with the feature’s design and improving user experience.

## Testing
- Created a goal → Verified the timer starts and no immediate redirect to /dashboard occurs.
- Waited for timer completion → Confirmed PostModal opens, and redirect to /dashboard happens only after post submission.

## Linked Issues
Fixes #<!-- Link to the issue this PR resolves -->
