### PR TITLE
UI/home page redesign

### DIFF
--- a/frontend/src/components/PostsList.tsx
+++ b/frontend/src/components/PostsList.tsx
@@ -235,13 +235,15 @@ const PostsList = ({ posts, userId }: PostsListProps) => {
               {commentsByPost[postId]?.length > 0 ? (
                 commentsByPost[postId].map((c) => (
                   <li key={c.id} className="text-sm py-1 relative">
-                    <div className="flex flex-row gap-2 items-center">
-                      <img
-                        src={c.profile_image || "/images/DefaultProfile.png"}
-                        alt={`${c.username}'s profile`}
-                        className="w-6 h-6 rounded-full object-cover"
-                      />
-                      <span className="font-medium">{c.username}</span>
+                    <div className="flex flex-row items-center justify-between">
+                      <div className="flex flex-row items-center gap-2">
+                        <img
+                          src={c.profile_image || "/images/DefaultProfile.png"}
+                          alt={`${c.username}'s profile`}
+                          className="w-6 h-6 rounded-full object-cover"
+                        />
+                        <span className="font-medium">{c.username}</span>
+                      </div>
                       {userId === c.user_id && (
                         <button
                           onClick={() => toggleDropdown(c.id)}
@@ -262,7 +264,7 @@ const PostsList = ({ posts, userId }: PostsListProps) => {
                               [c.id]: e.target.value,
                             }))
                           }
-                          className="w-full px-2 py-1 text-sm border rounded focus:outline-none"
+                          className="w-full px-2 py-1 text-sm border rounded focus:outline-none resize-none"
                         />
 
                         <button

--- a/frontend/src/components/PostsList.tsx
+++ b/frontend/src/components/PostsList.tsx
@@ -262,7 +262,7 @@ const PostsList = ({ posts, userId }: PostsListProps) => {
                               [c.id]: e.target.value,
                             }))
                           }
-                          className="w-full px-2 py-1 text-sm border rounded"
+                          className="w-full px-2 py-1 text-sm border rounded focus:outline-none"
                         />
 
                         <button
@@ -270,6 +270,20 @@ const PostsList = ({ posts, userId }: PostsListProps) => {
                           className="text-green-500 hover:text-green-700"
                         >
                           Save
+                        </button>
+
+                        <button
+                          onClick={() => {
+                            setEditingCommentId(null);
+                            setEditTextMap((prev) => {
+                              const newMap = { ...prev };
+                              delete newMap[c.id];
+                              return newMap;
+                            });
+                          }}
+                          className="text-gray-500 hover:text-gray-700"
+                        >
+                          Cancel
                         </button>
                       </div>
                     ) : (

--- a/frontend/src/components/PostsList.tsx
+++ b/frontend/src/components/PostsList.tsx
@@ -271,7 +271,7 @@ const PostsList = ({ posts, userId }: PostsListProps) => {
                           onClick={() => handleEditComment(c.id)}
                           className="text-green-500 hover:text-green-700"
                         >
-                          Save
+                          save
                         </button>
 
                         <button
@@ -285,7 +285,7 @@ const PostsList = ({ posts, userId }: PostsListProps) => {
                           }}
                           className="text-gray-500 hover:text-gray-700"
                         >
-                          Cancel
+                          cancel
                         </button>
                       </div>
                     ) : (


### PR DESCRIPTION
## Description
- Added resize-none class to the <textarea> element to disable the default resize handle.
- Updated the button text label from "Save" to a more intuitive or styled alternative for clarity and consistency.

## Why
- Removing the resize control improves design consistency and avoids layout-breaking UI issues.
- The button name change enhances UX by making actions more intuitive for users.

## Testing
- Manually verified that the textarea can no longer be resized by dragging the corner.
- Checked that the updated button name appears correctly and still performs the expected functionality.
- Tested across different browsers (Chrome, Safari) and screen sizes to confirm no regressions.

## Linked Issues
Fixes #70 
