### PR TITLE
🐛 fix: Restrict CORS origin to specific domain for enhanced security

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,7 +18,7 @@ const app = express();
 app.use(express.json());
 app.use(
   cors({
-    origin: "*",
+    origin: "http://3.106.254.86:3000",
     methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization"],
     credentials: true,


### PR DESCRIPTION
## Description
Changed the backend CORS configuration to explicitly allow requests from the deployed frontend hosted on EC2.
Updated the origin option to use the correct IP and port without a trailing slash.

## Why
The frontend was unable to communicate with the backend due to improper CORS settings.
The backend must only allow requests from the correct frontend origin (http://<ec2-ip>:3000) for security and functionality.

## Testing
- Updated origin in cors() middleware inside server.ts / index.ts.

## Linked Issues
Fixes #95 
